### PR TITLE
Fixes array configuration variables

### DIFF
--- a/lib/new_relic/agent/configuration/environment_source.rb
+++ b/lib/new_relic/agent/configuration/environment_source.rb
@@ -94,6 +94,8 @@ module NewRelic
             elsif value != nil
               self[config_key] = true
             end
+          elsif type == Array
+            self[config_key] = value.split(',')
           else
             ::NewRelic::Agent.logger.info("#{environment_key} does not have a corresponding configuration setting (#{config_key} does not exist).")
             ::NewRelic::Agent.logger.info("Run `rake newrelic:config:docs` or visit https://newrelic.com/docs/ruby/ruby-agent-configuration to see a list of available configuration settings.")

--- a/test/new_relic/agent/configuration/environment_source_test.rb
+++ b/test/new_relic/agent/configuration/environment_source_test.rb
@@ -82,6 +82,12 @@ module NewRelic::Agent::Configuration
       end
     end
 
+    def test_arrays_are_applied
+      ENV['NEW_RELIC_ATTRIBUTES_INCLUDE'] = 'jobs.sidekiq.args.*,jobs.resque.args.*'
+      source = EnvironmentSource.new
+      assert_equal %w| jobs.sidekiq.args.* jobs.resque.args.*  |, source[:'attributes.include']
+    end
+
     def test_set_log_config_from_environment
       ENV['NEW_RELIC_LOG'] = 'off/in/space.log'
       source = EnvironmentSource.new


### PR DESCRIPTION
The [documentation](https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration#attributes) mentions several options that take an array value.
Readers would expect those to be settable through the environment, but this is unsupported; e.g. this doesn't work:

```# .env
NEW_RELIC_ATTRIBUTES_INCLUDE=jobs.sidekiq.args.*,jobs.resque.args.*
```

This diff adds support for setting array options through comma-separate environment variables.